### PR TITLE
fix: generate exchange code with launcherAppClient2

### DIFF
--- a/src/kernel/core/manifest.ts
+++ b/src/kernel/core/manifest.ts
@@ -1,0 +1,50 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+export class Manifest {
+  static get() {
+    try {
+      const manifestsDirectory =
+        'C:\\ProgramData\\Epic\\EpicGamesLauncher\\Data\\Manifests'
+
+      const getFile = (filename: string) => {
+        const filePath = path.join(manifestsDirectory, filename)
+        const file = JSON.parse(readFileSync(filePath).toString()) as {
+          AppVersionString: string
+          LaunchCommand: string
+          DisplayName: string
+        }
+        const appVersionString = file.AppVersionString?.trim()
+
+        return {
+          AppVersionString: appVersionString ?? '',
+          DisplayName: file.DisplayName?.trim().toLowerCase() ?? '',
+          LaunchCommand: file.LaunchCommand?.trim() ?? '',
+          UserAgent: appVersionString
+            ? `Fortnite/${appVersionString}`
+            : '',
+        }
+      }
+
+      const responseItem = readdirSync(manifestsDirectory).find(
+        (filename) => {
+          if (filename.endsWith('item')) {
+            return getFile(filename).DisplayName === 'fortnite'
+          }
+
+          return false
+        }
+      )
+
+      if (responseItem) {
+        const manifestItem = getFile(responseItem)
+
+        return manifestItem
+      }
+    } catch (error) {
+      //
+    }
+
+    return null
+  }
+}

--- a/src/kernel/main.ts
+++ b/src/kernel/main.ts
@@ -5,13 +5,13 @@ import type { Settings } from '../types/settings'
 import path from 'node:path'
 import { app, BrowserWindow, ipcMain, Menu, shell } from 'electron'
 import schedule from 'node-schedule'
-// import { updateElectronApp } from 'update-electron-app'
 
 import { ElectronAPIEventKeys } from '../config/constants/main-process'
 
 import { AntiCheatProvider } from './core/anti-cheat-provider'
 import { Authentication } from './core/authentication'
 import { FortniteLauncher } from './core/launcher'
+import { Manifest } from './core/manifest'
 import { AccountsManager } from './startup/accounts'
 import { Application } from './startup/application'
 import { DataDirectory } from './startup/data-directory'
@@ -38,6 +38,12 @@ async function createWindow() {
     },
   })
 
+  const manifest = Manifest.get()
+
+  if (manifest) {
+    mainWindow.webContents.setUserAgent(manifest.UserAgent)
+  }
+
   // and load the index.html of the app.
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     mainWindow.webContents.openDevTools({
@@ -58,7 +64,6 @@ async function createWindow() {
 }
 
 Menu.setApplicationMenu(null)
-// updateElectronApp()
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.

--- a/src/services/config/caldera.ts
+++ b/src/services/config/caldera.ts
@@ -1,5 +1,7 @@
 import axios from 'axios'
 
+import { Manifest } from '../../kernel/core/manifest'
+
 /**
  * Caldera Service
  */
@@ -7,4 +9,14 @@ import axios from 'axios'
 export const calderaService = axios.create({
   baseURL:
     'https://caldera-service-prod.ecosec.on.epicgames.com/caldera/api/v1/launcher',
+})
+
+calderaService.interceptors.request.use((config) => {
+  const manifest = Manifest.get()
+
+  if (manifest) {
+    config.headers.setUserAgent(manifest.UserAgent)
+  }
+
+  return config
 })

--- a/src/services/config/oauth.ts
+++ b/src/services/config/oauth.ts
@@ -9,6 +9,8 @@ import {
   fortniteIOSGameClient,
 } from '../../config/fortnite/clients'
 
+import { Manifest } from '../../kernel/core/manifest'
+
 /**
  * OAuth Service
  */
@@ -39,6 +41,12 @@ axiosRetry(oauthService, {
 })
 
 oauthService.interceptors.request.use((config) => {
+  const manifest = Manifest.get()
+
+  if (manifest) {
+    config.headers.setUserAgent(manifest.UserAgent)
+  }
+
   if (!config.headers.getAuthorization()) {
     /**
      * Load Authorization header with default client on every request

--- a/src/services/config/public-account.ts
+++ b/src/services/config/public-account.ts
@@ -1,5 +1,7 @@
 import axios from 'axios'
 
+import { Manifest } from '../../kernel/core/manifest'
+
 /**
  * Public Account Service
  */
@@ -7,4 +9,14 @@ import axios from 'axios'
 export const publicAccountService = axios.create({
   baseURL:
     'https://account-public-service-prod.ol.epicgames.com/account/api/public/account',
+})
+
+publicAccountService.interceptors.request.use((config) => {
+  const manifest = Manifest.get()
+
+  if (manifest) {
+    config.headers.setUserAgent(manifest.UserAgent)
+  }
+
+  return config
 })

--- a/src/services/endpoints/oauth.ts
+++ b/src/services/endpoints/oauth.ts
@@ -16,11 +16,18 @@ export function getAccessTokenUsingAuthorizationCode(code: string) {
   })
 }
 
-export function getAccessTokenUsingExchangeCode(exchange_code: string) {
-  return oauthService.post<ExchangeCodeResponse>('/token', {
-    grant_type: 'exchange_code',
-    exchange_code,
-  })
+export function getAccessTokenUsingExchangeCode(
+  exchange_code: string,
+  config?: AxiosRequestConfig
+) {
+  return oauthService.post<ExchangeCodeResponse>(
+    '/token',
+    {
+      grant_type: 'exchange_code',
+      exchange_code,
+    },
+    config
+  )
 }
 
 export function getAccessTokenUsingDeviceAuth(


### PR DESCRIPTION
When Fortnite is opened using the selected account there is no problem, but when a new match starts in any mode, the account is kicked out of the game with this message:

![launch-error](https://github.com/Ciensprog/Aerial-Launcher/assets/26677431/187f13c4-ec49-44e5-8d73-37214156d45c)

This is because the account's exchange code was being used instead of the launcherAppClient2, this fix the issue and uses the correct exchange code to start the game.

---

Version affected: `v1.2.0-beta`

Issue: #1 