### PR TITLE
feat: hide sensible data

### DIFF
--- a/forge.env.d.ts
+++ b/forge.env.d.ts
@@ -47,3 +47,9 @@ declare module '@tanstack/react-router' {
     router: typeof router
   }
 }
+
+declare module 'csstype' {
+  interface Properties {
+    [key: `--${string}`]: string
+  }
+}

--- a/src/components/ui/extended/form/input-secret.tsx
+++ b/src/components/ui/extended/form/input-secret.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react'
+import type { ButtonProps } from '../../button'
+import type { InputProps } from '../../input'
+
+import { Eye, EyeOff } from 'lucide-react'
+import { useState } from 'react'
+
+import { Button } from '../../button'
+import { Input } from '../../input'
+
+import { cn } from '../../../../lib/utils'
+
+type Props = {
+  buttonProps?: ButtonProps
+  inputProps?: InputProps
+  iconButton?: ReactNode
+}
+
+export function InputSecret({
+  buttonProps,
+  iconButton,
+  inputProps,
+}: Props) {
+  const [isSecret, setIsSecret] = useState(true)
+  const icon = isSecret ? <Eye size={16} /> : <EyeOff size={16} />
+
+  return (
+    <div
+      className={cn(
+        'flex items-center overflow-hidden relative rounded-md'
+      )}
+    >
+      <Input
+        {...inputProps}
+        className={cn('pr-10 select-none', inputProps?.className)}
+        type={isSecret ? 'password' : 'text'}
+      />
+      <Button
+        variant="ghost"
+        type="button"
+        onClick={() => setIsSecret(!isSecret)}
+        {...buttonProps}
+        className={cn(
+          'absolute p-0 right-1 size-8 z-20',
+          buttonProps?.className
+        )}
+      >
+        {iconButton ? iconButton : icon}
+      </Button>
+    </div>
+  )
+}

--- a/src/routes/accounts/add/(authorization-code)/-page.tsx
+++ b/src/routes/accounts/add/(authorization-code)/-page.tsx
@@ -6,6 +6,7 @@ import {
   epicGamesLoginURL,
 } from '../../../../config/fortnite/links'
 
+import { InputSecret } from '../../../../components/ui/extended/form/input-secret'
 import {
   Accordion,
   AccordionContent,
@@ -28,7 +29,6 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../../components/ui/form'
-import { Input } from '../../../../components/ui/input'
 
 import { useHandlers } from '../-hooks'
 import { useSetupForm } from './-hooks'
@@ -101,9 +101,11 @@ export function AuthorizationCodePage() {
                 <FormItem>
                   <FormLabel>Paste Your Code</FormLabel>
                   <FormControl>
-                    <Input
-                      placeholder={`Example: ${exampleCode}`}
-                      {...field}
+                    <InputSecret
+                      inputProps={{
+                        placeholder: `Example: ${exampleCode}`,
+                        ...field,
+                      }}
                     />
                   </FormControl>
                   <FormMessage />

--- a/src/routes/accounts/add/(device-auth)/-page.tsx
+++ b/src/routes/accounts/add/(device-auth)/-page.tsx
@@ -1,3 +1,4 @@
+import { InputSecret } from '../../../../components/ui/extended/form/input-secret'
 import { Button } from '../../../../components/ui/button'
 import {
   Card,
@@ -12,7 +13,6 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../../components/ui/form'
-import { Input } from '../../../../components/ui/input'
 
 import { useSetupForm } from './-hooks'
 
@@ -34,7 +34,7 @@ export function DeviceAuthPage() {
                 <FormItem>
                   <FormLabel>Account Id</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <InputSecret inputProps={field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -47,7 +47,7 @@ export function DeviceAuthPage() {
                 <FormItem>
                   <FormLabel>Device Id</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <InputSecret inputProps={field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -60,7 +60,7 @@ export function DeviceAuthPage() {
                 <FormItem>
                   <FormLabel>Secret</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <InputSecret inputProps={field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/routes/accounts/add/(exchange-code)/-generate.tsx
+++ b/src/routes/accounts/add/(exchange-code)/-generate.tsx
@@ -1,5 +1,6 @@
 import { Clipboard } from 'lucide-react'
 
+import { InputSecret } from '../../../../components/ui/extended/form/input-secret'
 import { Button } from '../../../../components/ui/button'
 import {
   Card,
@@ -7,7 +8,6 @@ import {
   CardDescription,
   CardFooter,
 } from '../../../../components/ui/card'
-import { Input } from '../../../../components/ui/input'
 
 import { useGenerateHandlers } from './-hooks'
 
@@ -27,21 +27,18 @@ export function GenerateExchangeCodePage() {
             Account selected:{' '}
             <span className="font-bold">{selected?.displayName}</span>
           </CardDescription>
-          <div className="flex items-center relative">
-            <Input
-              placeholder="Generated code will be displayed here"
-              value={generatedCode ?? ''}
-              disabled
-            />
-            <Button
-              className="absolute p-0 right-1 size-8"
-              variant="ghost"
-              disabled={generatedCode === null}
-              onClick={handleCopyCode}
-            >
-              <Clipboard size={16} />
-            </Button>
-          </div>
+          <InputSecret
+            buttonProps={{
+              disabled: generatedCode === null,
+              onClick: handleCopyCode,
+            }}
+            inputProps={{
+              placeholder: 'Generated code will be displayed here',
+              value: generatedCode ?? '',
+              disabled: true,
+            }}
+            iconButton={<Clipboard size={16} />}
+          />
         </CardContent>
         <CardFooter className="space-x-6">
           <Button

--- a/src/routes/accounts/add/(exchange-code)/-page.tsx
+++ b/src/routes/accounts/add/(exchange-code)/-page.tsx
@@ -1,5 +1,6 @@
 import { exampleCode } from '../../../../config/constants/examples'
 
+import { InputSecret } from '../../../../components/ui/extended/form/input-secret'
 import { Button } from '../../../../components/ui/button'
 import {
   Card,
@@ -14,7 +15,6 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../../components/ui/form'
-import { Input } from '../../../../components/ui/input'
 import { Separator } from '../../../../components/ui/separator'
 
 import { GenerateExchangeCodePage } from './-generate'
@@ -52,9 +52,11 @@ export function ExchangeCodePage() {
                   <FormItem>
                     <FormLabel>Paste Your Code</FormLabel>
                     <FormControl>
-                      <Input
-                        placeholder={`Example: ${exampleCode}`}
-                        {...field}
+                      <InputSecret
+                        inputProps={{
+                          placeholder: `Example: ${exampleCode}`,
+                          ...field,
+                        }}
                       />
                     </FormControl>
                     <FormMessage />


### PR DESCRIPTION
By default, input text like Account Id, Device Id and Secret value in Device Auth page is visible in plain text.

Thinking in user privacy is better option hide this information and avoid share/show unintentionally, for example in share screen.

Before:
![image](https://github.com/Ciensprog/Aerial-Launcher/assets/26677431/5be4fe15-faba-49c3-812d-e4e256974d02)

After:
![image](https://github.com/Ciensprog/Aerial-Launcher/assets/26677431/f46df7ed-58b6-45d9-947d-18996a6fab34)
