### PR TITLE
feat: enable display name customization

### DIFF
--- a/src/components/account-list/hooks.ts
+++ b/src/components/account-list/hooks.ts
@@ -16,6 +16,29 @@ export function useAccountList() {
   const [open, setOpen] = useState(false)
   const accounts = Object.values(accountList)
 
+  const createKeywords = (account: AccountData) => {
+    const _keys: Array<string> = []
+    const customDisplayName = account.customDisplayName?.trim() ?? ''
+    const displayName = account.displayName
+    const provider = account.provider ?? ''
+
+    // [account.customDisplayName, account.provider]
+
+    if (customDisplayName !== '') {
+      _keys.push(customDisplayName)
+    }
+
+    if (displayName !== '') {
+      _keys.push(displayName)
+    }
+
+    if (provider !== '') {
+      _keys.push(provider)
+    }
+
+    return _keys.length > 0 ? _keys : undefined
+  }
+
   const customFilter = (
     value: string,
     search: string,
@@ -42,6 +65,7 @@ export function useAccountList() {
     open,
     selected,
 
+    createKeywords,
     customFilter,
     onSelect,
     setOpen,

--- a/src/components/account-list/index.tsx
+++ b/src/components/account-list/index.tsx
@@ -17,8 +17,15 @@ import { getStatusProvider } from '../../lib/statuses'
 import { cn } from '../../lib/utils'
 
 export function AccountList() {
-  const { accounts, customFilter, onSelect, open, selected, setOpen } =
-    useAccountList()
+  const {
+    accounts,
+    createKeywords,
+    customFilter,
+    onSelect,
+    open,
+    selected,
+    setOpen,
+  } = useAccountList()
 
   return (
     <Popover
@@ -44,7 +51,9 @@ export function AccountList() {
               {selected ? (
                 <span className="block w-full">
                   <span className="block truncate w-full">
-                    {selected.displayName}
+                    {selected.customDisplayName?.trim() !== ''
+                      ? selected.customDisplayName
+                      : selected.displayName}
                   </span>
                   <span className="block text-muted-foreground text-xs truncate">
                     {getStatusProvider(selected.provider)}
@@ -79,9 +88,7 @@ export function AccountList() {
                 <CommandItem
                   key={account.accountId}
                   value={account.displayName}
-                  keywords={
-                    account.provider ? [account.provider] : undefined
-                  }
+                  keywords={createKeywords(account)}
                   onSelect={onSelect(account)}
                 >
                   <Check
@@ -93,7 +100,11 @@ export function AccountList() {
                     )}
                   />
                   <div className="">
-                    <div className="">{account.displayName}</div>
+                    <div className="">
+                      {account.customDisplayName?.trim() !== ''
+                        ? account.customDisplayName
+                        : account.displayName}
+                    </div>
                     <div className="text-muted-foreground text-xs">
                       {getStatusProvider(account.provider)}
                     </div>

--- a/src/config/constants/main-process.ts
+++ b/src/config/constants/main-process.ts
@@ -36,6 +36,13 @@ export enum ElectronAPIEventKeys {
   ResponseProviderAndAccessTokenOnStartup = 'request:provider-with-access-token:on-startup:response',
 
   /**
+   * Accounts
+   */
+
+  UpdateAccountBasicInfo = 'account:custom-display-name:update',
+  ResponseUpdateAccountBasicInfo = 'account:custom-display-name:response',
+
+  /**
    * Authentication
    */
 

--- a/src/hooks/accounts.ts
+++ b/src/hooks/accounts.ts
@@ -13,6 +13,13 @@ export function useGetSelectedAccount() {
   return { selected }
 }
 
+export function useGetAccounts() {
+  const accountList = useAccountListStore((state) => state.accounts)
+  const accountsArray = Object.values(accountList)
+
+  return { accountsArray, accountList }
+}
+
 export function useRemoveSelectedAccount() {
   const removeAccount = useAccountListStore((state) => state.remove)
 

--- a/src/kernel/main.ts
+++ b/src/kernel/main.ts
@@ -1,4 +1,4 @@
-import type { AccountData } from '../types/accounts'
+import type { AccountBasicInfo, AccountData } from '../types/accounts'
 import type { AuthenticationByDeviceProperties } from '../types/authentication'
 import type { Settings } from '../types/settings'
 
@@ -186,6 +186,20 @@ app.on('ready', async () => {
     ElectronAPIEventKeys.LauncherStart,
     async (_, account: AccountData) => {
       await FortniteLauncher.start(currentWindow, account)
+    }
+  )
+
+  /**
+   * Accounts
+   */
+
+  ipcMain.on(
+    ElectronAPIEventKeys.UpdateAccountBasicInfo,
+    async (_, account: AccountBasicInfo) => {
+      await AccountsManager.add(account)
+      currentWindow.webContents.send(
+        ElectronAPIEventKeys.ResponseUpdateAccountBasicInfo
+      )
     }
   )
 

--- a/src/kernel/preload-actions/accounts.ts
+++ b/src/kernel/preload-actions/accounts.ts
@@ -1,0 +1,31 @@
+import type { AccountBasicInfo } from '../../types/accounts'
+
+import { ipcRenderer } from 'electron'
+
+import { ElectronAPIEventKeys } from '../../config/constants/main-process'
+
+/**
+ * Accounts
+ */
+
+export function updateCustomDisplayName(account: AccountBasicInfo) {
+  ipcRenderer.send(ElectronAPIEventKeys.UpdateAccountBasicInfo, account)
+}
+
+export function responseCustomDisplayName(callback: () => Promise<void>) {
+  const customCallback = () => {
+    callback().catch(() => {})
+  }
+  const rendererInstance = ipcRenderer.on(
+    ElectronAPIEventKeys.ResponseUpdateAccountBasicInfo,
+    customCallback
+  )
+
+  return {
+    removeListener: () =>
+      rendererInstance.removeListener(
+        ElectronAPIEventKeys.ResponseUpdateAccountBasicInfo,
+        customCallback
+      ),
+  }
+}

--- a/src/kernel/preload.ts
+++ b/src/kernel/preload.ts
@@ -3,6 +3,7 @@
 
 import { contextBridge } from 'electron'
 
+import * as accountsActions from './preload-actions/accounts'
 import * as authenticationActions from './preload-actions/authentication'
 import * as eventActions from './preload-actions/events'
 import * as generalActions from './preload-actions/general'
@@ -11,6 +12,7 @@ import * as requestActions from './preload-actions/requests'
 import * as scheduleActions from './preload-actions/schedules'
 
 export const availableElectronAPIs = {
+  ...accountsActions,
   ...authenticationActions,
   ...eventActions,
   ...generalActions,

--- a/src/kernel/startup/accounts.ts
+++ b/src/kernel/startup/accounts.ts
@@ -17,6 +17,7 @@ export class AccountsManager {
     const accounts: AccountDataList = result.accounts
       .map((account) => ({
         ...account,
+        customDisplayName: account.customDisplayName ?? '',
         provider: undefined,
         token: undefined,
       }))

--- a/src/layouts/header/hooks.ts
+++ b/src/layouts/header/hooks.ts
@@ -27,10 +27,17 @@ export function useHandlers() {
   useEffect(() => {
     const notificationLauncherListener =
       window.electronAPI.onNotificationLauncher(async (data) => {
+        const rawCustomDisplayName =
+          data.account.customDisplayName?.trim() ?? ''
+        const customDisplayNameText =
+          rawCustomDisplayName.length > 0
+            ? ` (${rawCustomDisplayName})`
+            : ''
+
         toast(
           data.status
-            ? `The game has been launched with the account ${data.account.displayName}`
-            : `An error has occurred launching game with account ${data.account.displayName}, try again later`
+            ? `The game has been launched with the account ${data.account.displayName}${customDisplayNameText}`
+            : `An error has occurred launching game with account ${data.account.displayName}${customDisplayNameText}, try again later`
         )
       })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,9 +10,18 @@ export function cn(...inputs: ClassValue[]) {
 
 export function sortAccounts(data: AccountDataRecord) {
   const result = Object.values(data)
-  const accounts = result.toSorted((itemA, itemB) =>
-    itemA.displayName.localeCompare(itemB.displayName)
-  )
+  const accounts = result.toSorted((itemA, itemB) => {
+    const _itemADisplayName =
+      (itemA.customDisplayName?.trim() ?? '') === ''
+        ? itemA.displayName
+        : itemA.customDisplayName ?? ''
+    const _itemBDisplayName =
+      (itemB.customDisplayName?.trim() ?? '') === ''
+        ? itemB.displayName
+        : itemB.customDisplayName ?? ''
+
+    return _itemADisplayName.localeCompare(_itemBDisplayName)
+  })
 
   const accountList = accounts.reduce((accumulator, current) => {
     accumulator[current.accountId] = current

--- a/src/lib/validations/schemas/accounts.ts
+++ b/src/lib/validations/schemas/accounts.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 export const accountBasicInformationSchema = z.object({
   accountId: z.string().min(1),
+  customDisplayName: z.string().optional(),
   deviceId: z.string().min(1),
   displayName: z.string().min(1),
   secret: z.string().min(1),

--- a/src/routes/settings/-display-name-customization/-hooks.ts
+++ b/src/routes/settings/-display-name-customization/-hooks.ts
@@ -1,0 +1,118 @@
+import type { ChangeEventHandler, FormEventHandler } from 'react'
+import type {
+  AccountBasicInfo,
+  AccountData,
+} from '../../../types/accounts'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { useAccountListStore } from '../../../state/accounts/list'
+
+import { useGetAccounts } from '../../../hooks/accounts'
+
+export function useAccounts() {
+  const { accountsArray } = useGetAccounts()
+  const [searchValue, setSearchValue] = useState('')
+
+  const accounts =
+    searchValue.length > 0
+      ? accountsArray.filter((account) => {
+          const currentSearchValue = searchValue.trim()
+
+          return (
+            account.displayName
+              .toLowerCase()
+              .includes(currentSearchValue) ||
+            account.customDisplayName
+              ?.toLowerCase()
+              .includes(currentSearchValue)
+          )
+        })
+      : accountsArray
+
+  const onChangeSearchValue: ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    setSearchValue(event.currentTarget.value.replace(/\s+/g, ' '))
+  }
+
+  return {
+    accounts,
+    accountsArray,
+    searchValue,
+
+    onChangeSearchValue,
+  }
+}
+
+export function useInputField({
+  defaultValue,
+}: {
+  defaultValue?: string
+}) {
+  const [value, setValue] = useState(defaultValue ?? '')
+
+  const onChangeInputValue: ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    setValue(event.currentTarget.value.replace(/\s+/g, ' '))
+  }
+
+  return {
+    value,
+
+    onChangeInputValue,
+  }
+}
+
+export function useActions() {
+  const addOrUpdate = useAccountListStore((state) => state.addOrUpdate)
+
+  const [isPending, setIsPending] = useState(false)
+  const _tmpAccount = useRef<AccountBasicInfo | null>(null)
+
+  useEffect(() => {
+    const listener = window.electronAPI.responseCustomDisplayName(
+      async () => {
+        if (_tmpAccount.current) {
+          addOrUpdate(_tmpAccount.current.accountId, _tmpAccount.current)
+        }
+
+        _tmpAccount.current = null
+
+        setIsPending(false)
+      }
+    )
+
+    return () => {
+      listener.removeListener()
+    }
+  }, [])
+
+  const onSubmit =
+    ({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      account: { provider, token, ...account },
+      value,
+    }: {
+      account: AccountData
+      value: string
+    }): FormEventHandler =>
+    (event) => {
+      event.preventDefault()
+
+      _tmpAccount.current = {
+        ...account,
+        customDisplayName: value.trim(),
+      }
+
+      setIsPending(true)
+      window.electronAPI.updateCustomDisplayName(_tmpAccount.current)
+    }
+
+  return {
+    isPending,
+
+    onSubmit,
+  }
+}

--- a/src/routes/settings/-display-name-customization/-index.tsx
+++ b/src/routes/settings/-display-name-customization/-index.tsx
@@ -35,14 +35,16 @@ export function DisplayNameCustomization() {
           </CardDescription>
         </CardHeader>
         <CardContent className="grid gap-4 pt-6">
-          <div className="mb-5">
-            <Input
-              className="pr-20"
-              placeholder={`Search on ${accountsArray.length} accounts...`}
-              value={searchValue}
-              onChange={onChangeSearchValue}
-            />
-          </div>
+          {accountsArray.length > 1 && (
+            <div className="mb-5">
+              <Input
+                className="pr-20"
+                placeholder={`Search on ${accountsArray.length} accounts...`}
+                value={searchValue}
+                onChange={onChangeSearchValue}
+              />
+            </div>
+          )}
           {accounts.length > 0 ? (
             accounts.map((account) => (
               <AccountItem

--- a/src/routes/settings/-display-name-customization/-index.tsx
+++ b/src/routes/settings/-display-name-customization/-index.tsx
@@ -1,0 +1,64 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+} from '../../../components/ui/card'
+import { Input } from '../../../components/ui/input'
+import { Separator } from '../../../components/ui/separator'
+
+import { useAccounts, useActions } from './-hooks'
+import { AccountItem } from './-item'
+
+export function DisplayNameCustomization() {
+  const { accounts, accountsArray, onChangeSearchValue, searchValue } =
+    useAccounts()
+  const { isPending, onSubmit } = useActions()
+
+  return (
+    <>
+      <Separator className="flex justify-center relative">
+        <div className="absolute bg-background font-semibold px-1.5 text-muted-foreground text-sm -top-2.5">
+          Display Name Customization
+        </div>
+      </Separator>
+
+      <Card className="w-full">
+        <CardHeader className="border-b">
+          <CardDescription>
+            Sometimes you could need a specific display name for
+            identifying an account. If you want, you can change the current
+            display name with a custom name.
+          </CardDescription>
+          <CardDescription className="text-muted-foreground/60">
+            Note: this only applies to the launcher accounts.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 pt-6">
+          <div className="mb-5">
+            <Input
+              className="pr-20"
+              placeholder={`Search on ${accountsArray.length} accounts...`}
+              value={searchValue}
+              onChange={onChangeSearchValue}
+            />
+          </div>
+          {accounts.length > 0 ? (
+            accounts.map((account) => (
+              <AccountItem
+                account={account}
+                onSubmit={onSubmit}
+                isPending={isPending}
+                key={account.accountId}
+              />
+            ))
+          ) : (
+            <div className="text-center text-muted-foreground">
+              No account found
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </>
+  )
+}

--- a/src/routes/settings/-display-name-customization/-item.tsx
+++ b/src/routes/settings/-display-name-customization/-item.tsx
@@ -1,0 +1,44 @@
+import type { AccountData } from '../../../types/accounts'
+
+import { Button } from '../../../components/ui/button'
+import { Input } from '../../../components/ui/input'
+
+import { useActions, useInputField } from './-hooks'
+
+export function AccountItem({
+  account,
+  isPending,
+  onSubmit,
+}: {
+  account: AccountData
+} & Pick<ReturnType<typeof useActions>, 'isPending' | 'onSubmit'>) {
+  const { onChangeInputValue, value } = useInputField({
+    defaultValue: account.customDisplayName,
+  })
+
+  return (
+    <form
+      className="flex items-center overflow-hidden relative rounded-md"
+      onSubmit={onSubmit({
+        account,
+        value,
+      })}
+    >
+      <Input
+        className="pr-20"
+        placeholder={account.displayName}
+        value={value}
+        onChange={onChangeInputValue}
+        disabled={isPending}
+      />
+      <Button
+        type="submit"
+        variant="secondary"
+        className="absolute h-8 px-2 right-1 w-auto z-20 disabled:cursor-not-allowed disabled:pointer-events-auto"
+        disabled={isPending}
+      >
+        Change
+      </Button>
+    </form>
+  )
+}

--- a/src/routes/settings/route.tsx
+++ b/src/routes/settings/route.tsx
@@ -22,6 +22,9 @@ import {
 } from '../../components/ui/form'
 import { Input } from '../../components/ui/input'
 
+import { useGetAccounts } from '../../hooks/accounts'
+
+import { DisplayNameCustomization } from './-display-name-customization/-index'
 import { useSetupForm } from './-hooks'
 
 export const Route = createRoute({
@@ -50,43 +53,48 @@ export const Route = createRoute({
 })
 
 function Content() {
+  const { accountsArray } = useGetAccounts()
   const { form, onSubmit } = useSetupForm()
 
   return (
     <div className="flex flex-grow">
       <div className="flex items-center justify-center w-full">
-        <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(onSubmit)}
-            className="max-w-sm w-full"
-          >
-            <Card className="max-w-sm w-full">
-              <CardContent className="grid gap-4 pt-6">
-                <FormField
-                  control={form.control}
-                  name="path"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Custom Path</FormLabel>
-                      <FormControl>
-                        <Input {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </CardContent>
-              <CardFooter className="space-x-6">
-                <Button
-                  type="submit"
-                  className="w-full"
-                >
-                  Update Information
-                </Button>
-              </CardFooter>
-            </Card>
-          </form>
-        </Form>
+        <div className="flex flex-col gap-8 max-w-md w-full">
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(onSubmit)}
+              className="w-full"
+            >
+              <Card className="w-full">
+                <CardContent className="grid gap-4 pt-6">
+                  <FormField
+                    control={form.control}
+                    name="path"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Custom Path</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </CardContent>
+                <CardFooter className="space-x-6">
+                  <Button
+                    type="submit"
+                    className="w-full"
+                  >
+                    Update Information
+                  </Button>
+                </CardFooter>
+              </Card>
+            </form>
+          </Form>
+
+          {accountsArray.length > 0 && <DisplayNameCustomization />}
+        </div>
       </div>
     </div>
   )

--- a/src/state/accounts/list.ts
+++ b/src/state/accounts/list.ts
@@ -28,7 +28,10 @@ export const useAccountListStore = create<AccountListState>()(
         set({
           accounts: sortAccounts({
             ...accounts,
-            [accountId]: account,
+            [accountId]: {
+              ...current,
+              ...account,
+            },
           }),
         })
       }


### PR DESCRIPTION
Sometimes you could need a specific display name for identifying an account. If you want, you can change the current display name with a custom name.

> Note: this only applies to the launcher accounts.